### PR TITLE
feature(data-properties): add setter to object data

### DIFF
--- a/packages/istanbul-lib-coverage/lib/data-properties.js
+++ b/packages/istanbul-lib-coverage/lib/data-properties.js
@@ -6,6 +6,9 @@ module.exports = function dataProperties(klass, properties) {
             enumerable: true,
             get() {
                 return this.data[p];
+            },
+            set(value) {
+                this.data[p] = value;
             }
         });
     });


### PR DESCRIPTION
Add a setter for `data-properties`, nightwatch tries to replace environment variables on each data from `coverageReporter` object, since there is no setter, nightwatch will crash with this following error :

```
Cannot set property path of #<FileCoverage> which has only a getter
    Stack Trace :
    at Settings.replaceEnvVariables (/home/yann/development/f4/thor-front/node_modules/nightwatch/lib/settings/settings.js:33:23)
    at Settings.replaceEnvVariables (/home/yann/development/f4/thor-front/node_modules/nightwatch/lib/settings/settings.js:29:20)
    at Settings.replaceEnvVariables (/home/yann/development/f4/thor-front/node_modules/nightwatch/lib/settings/settings.js:29:20)
    at Settings.replaceEnvVariables (/home/yann/development/f4/thor-front/node_modules/nightwatch/lib/settings/settings.js:29:20)
    at Settings.replaceEnvVariables (/home/yann/development/f4/thor-front/node_modules/nightwatch/lib/settings/settings.js:29:20)
    at Settings.replaceEnvVariables (/home/yann/development/f4/thor-front/node_modules/nightwatch/lib/settings/settings.js:29:20)
    at Settings.init (/home/yann/development/f4/thor-front/node_modules/nightwatch/lib/settings/settings.js:511:14)
    at Settings.fromClient (/home/yann/development/f4/thor-front/node_modules/nightwatch/lib/settings/settings.js:74:14)
    at new NightwatchClient (/home/yann/development/f4/thor-front/node_modules/nightwatch/lib/core/client.js:180:30)
    at NightwatchClient.create (/home/yann/development/f4/thor-front/node_modules/nightwatch/lib/core/client.js:146:20)
```